### PR TITLE
fix bug in testing data

### DIFF
--- a/js/collapsibleTangleTree.js
+++ b/js/collapsibleTangleTree.js
@@ -175,9 +175,12 @@ function preprocessChart(chart) {
             element['direct_children'] = ['ScRNA-seqLevel3']
         }
         else if (element['id'] == 'ScRNA-seqLevel3') {
+            element['children'] = ['ScRNA-seqLevel4']
             element['direct_children'] = ['ScRNA-seqLevel4']
+
         }
         else {
+            element['children'] = []
             element['direct_children'] = []
         }
 


### PR DESCRIPTION
This bug was causing the HTAN viz not being able to "collapse" correctly when clicking on "ScRNA-seqLevel2". It turned out that it was because in the data structure, "ScRNA-seqLevel3" didn't "realize" that it has child "ScRNA-seqLevel4"