### PR TITLE
change font size of text when hover over

### DIFF
--- a/js/collapsibleTangleTree.js
+++ b/js/collapsibleTangleTree.js
@@ -195,7 +195,6 @@ function createCollapsibleTree(chart, schemaOption) {
 
     //begin to draw tree
     var InteractivePartNode = chart['nodes']
-    var links = chart['links']
     var bundles = chart['bundles']
 
     //by default, all the children have been expanded. 
@@ -335,6 +334,9 @@ function createCollapsibleTree(chart, schemaOption) {
         //change the stroke width of node
         d3.selectAll("#node_" + textId).style("stroke-width", "10");
 
+        //change the size of text
+        d3.selectAll("#text_" + textId).style("font-size", "12")
+
         //change the stroke width of links
         d3.selectAll("path.link").filter(function (d) {
             var linkId = d.id
@@ -347,6 +349,9 @@ function createCollapsibleTree(chart, schemaOption) {
 
         //change the stroke width of node
         d3.selectAll("#node_" + textId).style("stroke-width", "8");
+
+        //change the size of text
+        d3.selectAll("#text_" + textId).style("font-size", "10")
 
         //change the stroke width of links
         d3.selectAll("path.link").filter(function (d) {


### PR DESCRIPTION
This is also related to the issue [here](https://github.com/Sage-Bionetworks/schematic/issues/883)

Here's a brief summary of the interaction effect: 

1) When hovering over, the size of the node changes from 8 to 10
2) similarly, the size of text changes from size 10 to 12
3) stroke of links changed from 2 to 4