### PR TITLE
avoid repeated api calls when generating attribute table

### DIFF
--- a/js/collapsibleTangleTree.js
+++ b/js/collapsibleTangleTree.js
@@ -318,7 +318,10 @@ function createCollapsibleTree(chart, schemaOption) {
 
     }
 
-    function generateAttributeTable(schemaOption, id) {
+    //////////////////generate data for attribute table 
+    var merged_data = generateAttributeData(schemaOption)
+
+    function generateAttributeData(schemaOption) {
         if (schemaOption == 'HTAN') {
             var schema_name = 'HTAN'
         } else if (schemaOption == 'NF Tools Registry') {
@@ -327,11 +330,17 @@ function createCollapsibleTree(chart, schemaOption) {
 
         var merged_data = getRequestedCSV(schema_name);
 
+        return merged_data
+    }
+
+    //define function related to generating attribute table
+    function generateAttributeTable(id) {
         merged_data.then(data => {
             drawTable(data, id)
         })
     }
 
+    //define mouseover and mouseout effect
     function mouseover(d) {
         var textId = d.id
 
@@ -435,7 +444,7 @@ function createCollapsibleTree(chart, schemaOption) {
 
         update(ChangeableNode, bundles);
 
-        generateAttributeTable(schemaOption, d.id);
+        generateAttributeTable(d.id);
 
 
     }


### PR DESCRIPTION
I noticed that whenever users click on a node in the visualization, I always trigger an API call to generate the attribute table. However, this could be avoided. We only need to call the endpoint to get data related to a given schema once, and then use a different function for filtering. 